### PR TITLE
GPlusテーマ公式ブランチdev-1.2からのマージなど

### DIFF
--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev.scss
@@ -5,9 +5,11 @@
 
 @charset "UTF-8";
 
+// @import 'application';
 @import 'application';
 @import 'dark-gplus-theme-for-mastodon-dev/basics';
 @import 'dark-gplus-theme-for-mastodon-dev/components';
+@import 'dark-gplus-theme-for-mastodon-dev/emoji-picker';
 @import 'dark-gplus-theme-for-mastodon-dev/tables';
 @import 'dark-gplus-theme-for-mastodon-dev/columns';
 @import 'dark-gplus-theme-for-mastodon-dev/lists';

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/_functions.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/_functions.scss
@@ -1,0 +1,15 @@
+@charset "UTF-8";
+
+
+
+@function adjust-lightness ($color, $lightness) {
+	@if (lightness($color) - $lightness <= 0 and lightness($color) + $lightness < 100) {
+		@return lighten($color, $lightness);
+	}
+
+	@if (0 < lightness($color) - $lightness and 100 <= lightness($color) + $lightness) {
+		@return darken($color, $lightness);
+	}
+
+	@return change-color($color, $lightness: $lightness);
+}

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/_variables.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/_variables.scss
@@ -15,7 +15,7 @@ $verified-color: #4caf50;
 $primary-text-color: #ffffff;
 $primary-lighter1-text-color: change-color($color: $primary-text-color, $lightness: 62%, $alpha: 1.0); // ex: 時間表示
 $primary-lighter2-text-color: change-color($color: $primary-text-color, $lightness: 38%, $alpha: 1.0); // ex: 通知メッセージ表示
-$secondary-text-color: #2962ff; // ex: リンク
+$secondary-text-color: #2196F3; // ex: リンク
 $secondary-lighter1-text-color: #00bfff; // ex: アカウントTLのユーザーID
 $light-text-color: #000000;
 $light-darker1-text-color: darken($light-text-color, 15%);
@@ -30,7 +30,7 @@ $icon-active-color: $active-color;
 
 // Background colors
 $base-color: #212121;
-$base-lighter1-color: #424242;
+$base-lighter1-color: #2d2d2d;
 $base-darker1-color: #000000;
 
 $column-header-color: $base-lighter1-color;
@@ -38,7 +38,7 @@ $column-header-hover-color: change-color($color: $column-header-color, $lightnes
 
 $status-color: $base-lighter1-color;
 $status-direct-color: darken($status-color, 5%);
-$status-actionbar-color: change-color($color: $status-color, $lightness: 2%);
+$status-actionbar-color: darken($status-color, 2%);
 
 $account-color: $base-lighter1-color;
 $account-foreground-color: $base-darker1-color;
@@ -61,8 +61,16 @@ $setting-toggle-checked-color: change-color($color: $checked-color, $alpha: 0.5)
 $setting-toggle-thumb-color: #fafafa;
 $setting-toggle-thumb-checked-color: $checked-color;
 
+$setting-emphasis-color: $verified-color;
+
 $dashboard-counters-base-color: $base-color;
 $dashboard-counters-hover-color: lighten($base-color, 2%);
+
+$log-entry-color: $base-lighter1-color;
+$log-entry-extra-color: $base-color;
+$log-entry-extra--neutral-color: $valid-color;
+$log-entry-extra--old-color: $active-color;
+$log-entry-extra--new-color: $verified-color;
 
 $explore-header-color: lighten($accent-color, 16%);
 $explore-directory-color: $base-lighter1-color;

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/accounts.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/accounts.scss
@@ -12,9 +12,14 @@
 	.account {
 		&__display-name {
 			color: $secondary-text-color;
-	
 			strong { color: $primary-text-color }
 		}
+	}
+
+	&-role {
+		color: $primary-lighter2-text-color;
+		background-color: rgba($base-separation-color, 0.1);
+		border-color: rgba($base-separation-color, 0.5);
 	}
 }
 
@@ -29,11 +34,70 @@
 	.account__header {
 		background-color: $account-foreground-color;
 
-		> div { background-color: inherit }
+		> div { background-color: inherit } // -> v2.7.4
 
 		.account__header {
 			&__username { color: $secondary-lighter1-text-color }
 			&__fields { @extend .account__header__fields; }
+
+			&__image { // v2.8.0 ->
+				&::after {
+					content: "";
+
+					position: absolute;
+					top: auto;
+					left: 0;
+					bottom: 0;
+	
+					width: 100%;
+					height: 30%;
+					background: $account-header-image-shadow-color;
+					box-shadow: none;
+				}
+
+				> img:not([src]),
+				> img[src$="/headers/original/missing.png"] {
+					content: url("https://raw.githubusercontent.com/GenbuProject/GPlusTheme-for-Mastodon/asset/account-default_header.jpg");
+				}
+			}
+
+			&__bar { // v2.8.0 ->
+				background-color: $base-lighter1-color;
+
+				.account__header {
+					&__tabs {
+						.avatar {
+							.account__avatar {
+								border-color: $base-lighter1-color;
+								border-radius: 50%;
+							}
+						}
+
+						&__buttons {
+							.icon-button { border: 0 }
+						}
+
+						&__name {
+							h1 { color: $primary-text-color }
+							small { color: $secondary-text-color }
+						}
+					}
+
+					&__bio {
+						.account__header {
+							&__content { color: $primary-text-color }
+							&__fields { border-color: $base-separation-color }
+						}
+					}
+
+					&__extra {
+						&__links {
+							&, a { color: $primary-lighter1-text-color }
+							strong { color: $primary-lighter2-text-color }
+						}
+					}
+				}
+			}
 		}
 
 		.account--action-button {
@@ -53,7 +117,7 @@
 		&__disclaimer,
 		&__action-bar,
 		&__section-headline {
-			background: $column-header-color;
+			background: $base-lighter1-color;
 			border-color: $base-separation-color;
 		}
 
@@ -71,12 +135,30 @@
 				color: $primary-text-color;
 	
 				&.active {
-					color: $primary-lighter1-text-color;
+					color: $active-color;
 	
 					&::before { border-color: transparent transparent $base-separation-color }
 					&::after { border-color: transparent transparent $status-color }
 				}
 			}
+		}
+	}
+}
+
+.account-authorize__wrapper {
+	@include status-shadow;
+	background: $base-lighter1-color;
+
+	&:focus { @include status-focus-shadow; }
+
+	.account {
+		&__header__content {
+			color: $primary-lighter2-text-color;
+		}
+	
+		&--panel {
+			background: $account-color;
+			border-color: $base-separation-color;
 		}
 	}
 }
@@ -88,7 +170,7 @@
 		dt,
 		dd {
 			color: $primary-text-color;
-			background: $column-header-color;
+			background: $base-lighter1-color;
 		}
 
 		dd {

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/columns.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/columns.scss
@@ -98,7 +98,6 @@
 .column {
 	.column-header {
 		@include column-shadow;
-		@include material-card-radius;
 		background: $column-header-color;
 
 		&.active {
@@ -158,11 +157,8 @@
 	}
 
 	.column {
-		&-subheading {
-			color: $secondary-text-color;
-			background: $base-color;
-			border-top: $base-separation-color solid 1px;
-		}
+		&-subheading,
+		&-link__badge { background: $base-color }
 	
 		&-link {
 			color: $primary-text-color;
@@ -184,6 +180,8 @@
 			article {
 				margin: 1em 0;
 				&:first-of-type { margin: 0 }
+
+				&:focus { outline: none }
 			}
 		}
 

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/components-button.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/components-button.scss
@@ -11,11 +11,11 @@
 	width: 3.6rem;
 	height: 3.6rem;
 
-	&::active {
+	&:active {
 		background-color: $active-color;
 	}
 
-	&::hover {
+	&:hover {
 		background-color: $floating-acton-button-hover-color;
 	}
 }

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/components-status-card.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/components-status-card.scss
@@ -1,0 +1,12 @@
+@charset "UTF-8";
+
+@import 'variables';
+
+
+
+.status-card {
+	color: $primary-lighter1-text-color;
+	&__title, &__description { color: $primary-lighter2-text-color }
+
+	&__image { background: transparent }
+}

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/components.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/components.scss
@@ -3,3 +3,4 @@
 @import 'components-button';
 @import 'components-card';
 @import 'components-dropdown';
+@import 'components-status-card';

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/emoji-picker.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/emoji-picker.scss
@@ -1,0 +1,68 @@
+@charset "UTF-8";
+
+@import 'variables';
+@import 'mixins';
+
+
+
+.emoji-mart {
+    &-bar {
+        border: 0 solid $base-separation-color;
+
+        &:first-child {
+            border-top-left-radius: 2px;
+            border-top-right-radius: 2px;
+            background-color: $base-color;
+        }
+    }
+
+    &-anchors {
+        color: $icon-color;
+    }
+    &-anchor {
+        &-selected {
+            color: $icon-active-color;
+
+            &:hover {
+                color: $icon-active-color;
+            }
+        }
+
+        &-bar {
+            background-color: $icon-active-color;
+        }
+    }
+
+    &-search {
+        background-color: $base-lighter1-color;
+    }
+    &-search input {
+        color: $primary-text-color;
+        background-color: $form-color;
+        border: 0px solid #ffffff00;
+    }
+
+    &-category-label span {
+        color: $primary-text-color;
+        background-color: $base-lighter1-color;
+    }
+
+    &-scroll {
+        background-color: $base-lighter1-color;
+    }
+}
+
+.emoji-picker-dropdown {
+    &__modifiers {
+        &__menu {
+            @include status-shadow;
+            @include material-card-radius;
+            background-color: $base-lighter1-color;
+        }
+    }
+
+    &__menu {
+        @include column-shadow;
+        background-color: $base-lighter1-color;
+    }
+}

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/explore.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/explore.scss
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 
 @import 'variables';
+@import 'mixins';
 
 
 
@@ -11,6 +12,9 @@
 		h1 { color: $primary-text-color }
 		p { color: $primary-lighter2-text-color }
 	}
+
+	.directory,
+	.notice-widget { @include column-shadow; }
 
 	.directory {
 		background: $explore-directory-color;
@@ -23,9 +27,14 @@
 		}
 
 		&__tag {
-			a { background: $explore-directory-color }
-			h4 { color: $primary-text-color }
+			& > a {
+				@include status-shadow;
+				background: $explore-directory-color;
+			}
+
+			h4 { color: $primary-lighter2-text-color }
 			.fa, small { color: $primary-lighter1-text-color }
+			.trends__item__current { color: $primary-text-color }
 		}
 	}
 

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/keyboard_shortcuts.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/keyboard_shortcuts.scss
@@ -1,0 +1,21 @@
+@charset "UTF-8";
+
+@import 'variables';
+@import 'mixins';
+
+
+
+.keyboard-shortcuts {
+	kbd {
+		@include status-shadow;
+
+		color: $primary-text-color;
+		background-color: $base-lighter1-color;
+		border-color: $base-darker1-color;
+
+		margin: 0 0.25em;
+
+		&:first-child { margin-left: 0 }
+		&:last-child { margin-right: 0 }
+	}
+}

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/lists.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/lists.scss
@@ -22,13 +22,34 @@
 }
 
 .modal-root {
+	.column-inline-form {
+		background: $column-header-color;
+		
+		.setting-text {
+			color: $primary-text-color;
+			&:active, &:focus { color: $primary-lighter2-text-color }
+		}
+	}
+
 	.list-editor {
 		background: $base-color;
-		
 		h4 { background: $column-header-color }
 
 		.drawer__pager {
 			.drawer__inner { background: $column-header-color }
+		}
+	}
+
+	.list-adder {
+		background: $base-color;
+
+		.column-inline-form { border-bottom: 1px solid $base-separation-color }
+
+		&__account,
+		&__lists { background: $column-header-color }
+
+		&__lists {
+			.list { border-color: $base-separation-color }
 		}
 	}
 }

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/profile.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/profile.scss
@@ -23,7 +23,7 @@
 		svg path {
 			/* Only for Itabashi-don */
 			&:not(#Mastodon):not(#Itabashi) { fill: $secondary-text-color !important }
-			&:last-child { fill: $base-lighter1-color !important }
+			&#Mastodon { fill: $base-lighter1-color !important }
 		}
 	}
 
@@ -36,6 +36,8 @@
 			@media screen and (min-width: 600px) { height: 500px }
 
 			&::after {
+				content: "";
+				
 				position: absolute;
 				top: auto;
 				left: 0;
@@ -112,7 +114,7 @@
 						svg path {
 							/* Only for Itabashi-don */
 							&:not(#Mastodon):not(#Itabashi) { fill: $base-lighter1-color !important }
-							&:last-child { fill: $secondary-text-color !important }
+							&#Mastodon { fill: $secondary-text-color !important }
 						}
 					}
 				}
@@ -147,8 +149,11 @@
 		}
 	}
 
+	.public-account-bio,
+	.endorsements-widget,
+	.hero-widget { @include status-shadow; }
+
 	.public-account-bio {
-		@include column-shadow;
 		background: $base-lighter1-color;
 		
 		.account__header__content { color: $primary-text-color }
@@ -156,8 +161,6 @@
 	}
 
 	.endorsements-widget {
-		@include column-shadow;
-
 		padding-bottom: 0;
 		border-radius: 4px;
 
@@ -168,8 +171,6 @@
 	}
 
 	.hero-widget {
-		@include column-shadow;
-
 		&__img { background: $base-color }
 		&__text {
 			background: $base-lighter1-color;
@@ -224,7 +225,7 @@
 			svg path {
 				/* Only for Itabashi-don */
 				&:not(#Mastodon):not(#Itabashi) { fill: $secondary-text-color !important }
-				&:last-child { fill: $base-lighter1-color !important }
+				&#Mastodon { fill: $base-lighter1-color !important }
 			}
 		}
 	}

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-account.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-account.scss
@@ -10,7 +10,15 @@
 			> a {
 				position: relative;
 
-				.card__img { border-bottom: 1px solid $base-separation-color }
+				.card__img {
+					border-bottom: 1px solid $base-separation-color;
+
+					> img:not([src]),
+					> img[src="/headers/original/missing.png"] {
+						content: url("https://raw.githubusercontent.com/GenbuProject/GPlusTheme-for-Mastodon/asset/account-default_header.jpg");
+					}
+				}
+				
 				.card__bar {
 					position: static;
 					padding-top: 30%;
@@ -29,6 +37,8 @@
 						img {
 							width: 128px;
 							height: 128px;
+
+							border-radius: 50%;
 						}
 					}
 			

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-dashboard.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-dashboard.scss
@@ -18,7 +18,9 @@
 			}
 		}
 
+		&__text,
 		&__num { color: $primary-text-color }
+		
 		&__label { color: $primary-lighter1-text-color }
 	}
 

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-directory_tag.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-directory_tag.scss
@@ -1,0 +1,21 @@
+@charset "UTF-8";
+
+@import 'variables';
+
+
+
+.admin-wrapper {
+	.content {
+		.directory__tag {
+			& > a,
+			& > div { background: $setting-base-color }
+
+			h4 {
+				& { color: $primary-lighter2-text-color }
+				.fa, small { color: $primary-lighter1-text-color }
+			}
+
+			.trends__item__current { color: $primary-text-color }
+		}
+	}
+}

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-log.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-log.scss
@@ -1,0 +1,30 @@
+@charset "UTF-8";
+
+@import 'variables';
+
+
+
+.log-entry {
+	.log-entry {
+		&__header {
+			color: $primary-lighter2-text-color;
+			background: $log-entry-color;
+
+			.username,
+			.target,
+			a { color: $secondary-text-color }
+		}
+
+		&__timestamp { color: $primary-lighter1-text-color }
+		&__icon { color: $icon-color }
+
+		&__extras {
+			color: $primary-text-color;
+			background: $log-entry-extra-color;
+
+			.diff-neutral { color: $log-entry-extra--neutral-color }
+			.diff-old { color: $log-entry-extra--old-color }
+			.diff-new { color: $log-entry-extra--new-color }
+		}
+	}
+}

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-report.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings-report.scss
@@ -45,14 +45,26 @@
 	}
 
 	&__row {
-		background: $base-lighter1-color;
-		border-color: $base-separation-color;
+		&, &:nth-child(2n) { background: $base-lighter1-color }
+		&:hover, &:nth-child(2n):hover { background: $column-header-hover-color }
 
-		&:hover { background: $column-header-hover-color }
+		border-color: $base-separation-color;
 
 		&__content {
 			.status__content { color: $primary-text-color }
 			.detailed-status__meta { color: $primary-lighter1-text-color }
+
+
+			.accounts-table { // v2.8.0 ->
+				.accounts-table {
+					&__count {
+						& {color: $primary-text-color }
+						small { color: $primary-lighter1-text-color }
+					}
+				}
+
+				td .account { background: inherit }
+			}
 		}
 	}
 }

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/settings.scss
@@ -4,7 +4,9 @@
 @import 'mixins';
 @import 'settings-account';
 @import 'settings-report';
+@import 'settings-log';
 @import 'settings-dashboard';
+@import 'settings-directory_tag';
 
 
 
@@ -82,7 +84,10 @@ body.admin {
 			.radio label { color: $primary-text-color }
 		}
 
-		&-copy { background: $base-color }
+		&-copy {
+			background: $base-color;
+			border-color: $base-separation-color;
+		}
 	}
 
 	.check_boxes {
@@ -123,7 +128,20 @@ body.admin {
 		}
 	}
 
-	.hint, p.hint { color: $primary-lighter1-text-color !important }
+	.hint, p.hint {
+		color: $primary-lighter1-text-color !important;
+
+		code {
+			color: $light-text-color;
+			background: $setting-emphasis-color;
+		}
+	}
+
+	.recommended {
+		color: $verified-color;
+		background-color: transparentize($verified-color, 0.75);
+		border-color: $verified-color;
+	}
 
 	.label_input {
 		&__append { color: $primary-lighter1-text-color }
@@ -182,11 +200,19 @@ body.admin {
 	}
 }
 
-label {
-	&[for=user_setting_default_privacy_public],
-	&[for=user_setting_default_privacy_unlisted] {
-		color: $active-text-color !important;
+.new_form_two_factor_confirmation {
+	.qr-wrapper {
+		.qr-code { box-shadow: none }
+		.qr-alternative { color: $secondary-lighter1-text-color }
 	}
+}
+
+label,
+select#user_setting_default_privacy {
+	&[for=user_setting_default_privacy_public],
+	&[for=user_setting_default_privacy_unlisted],
+	option[value="public"],
+	option[value="unlisted"] { color: $active-text-color !important }
 }
 
 .column-header__collapsible__extra {

--- a/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/statuses.scss
+++ b/app/javascript/styles/dark-gplus-theme-for-mastodon-dev/statuses.scss
@@ -56,19 +56,17 @@
 }
 
 .detailed-status {
-	.detailed-status {
-		&__display-name {
-			color: $secondary-text-color;
-	
-			strong { color: $primary-text-color }
-		}
-	
-		&__meta {
-			.detailed-status__datetime { color: $primary-lighter1-text-color }
-	
-			.detailed-status__link {
-				.fa.fa-star { vertical-align: middle }
-			}
+	&__display-name {
+		color: $secondary-text-color;
+
+		strong { color: $primary-text-color }
+	}
+
+	&__meta {
+		.detailed-status__datetime { color: $primary-lighter1-text-color }
+
+		.detailed-status__link {
+			.fa.fa-star { vertical-align: middle }
 		}
 	}
 	

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev.scss
@@ -5,9 +5,11 @@
 
  @charset "UTF-8";
 
+ // @import 'application';
  @import 'application';
  @import 'gplus-theme-for-mastodon-dev/basics';
  @import 'gplus-theme-for-mastodon-dev/components';
+ @import 'gplus-theme-for-mastodon-dev/emoji-picker';
  @import 'gplus-theme-for-mastodon-dev/tables';
  @import 'gplus-theme-for-mastodon-dev/columns';
  @import 'gplus-theme-for-mastodon-dev/lists';

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/_functions.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/_functions.scss
@@ -1,0 +1,15 @@
+@charset "UTF-8";
+
+
+
+@function adjust-lightness ($color, $lightness) {
+	@if (lightness($color) - $lightness <= 0 and lightness($color) + $lightness < 100) {
+		@return lighten($color, $lightness);
+	}
+
+	@if (0 < lightness($color) - $lightness and 100 <= lightness($color) + $lightness) {
+		@return darken($color, $lightness);
+	}
+
+	@return change-color($color, $lightness: $lightness);
+}

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/_variables.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/_variables.scss
@@ -34,11 +34,11 @@ $base-lighter1-color: #ffffff;
 $base-darker1-color: rgba(0, 0, 0, 0.4);
 
 $column-header-color: $base-lighter1-color;
-$column-header-hover-color: change-color($color: $column-header-color, $lightness: 90%);
+$column-header-hover-color: darken($column-header-color, 10%);
 
 $status-color: $base-lighter1-color;
 $status-direct-color: darken($status-color, 5%);
-$status-actionbar-color: change-color($color: $status-color, $lightness: 98%);
+$status-actionbar-color: darken($status-color, 2%);
 
 $account-color: $base-lighter1-color;
 $account-foreground-color: $base-darker1-color;
@@ -61,8 +61,16 @@ $setting-toggle-checked-color: change-color($color: $checked-color, $alpha: 0.5)
 $setting-toggle-thumb-color: #fafafa;
 $setting-toggle-thumb-checked-color: $checked-color;
 
+$setting-emphasis-color: $verified-color;
+
 $dashboard-counters-base-color: $base-color;
 $dashboard-counters-hover-color: lighten($base-color, 2%);
+
+$log-entry-color: $base-lighter1-color;
+$log-entry-extra-color: $base-color;
+$log-entry-extra--neutral-color: $valid-color;
+$log-entry-extra--old-color: $active-color;
+$log-entry-extra--new-color: $verified-color;
 
 $explore-header-color: lighten($accent-color, 16%);
 $explore-directory-color: $base-lighter1-color;

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/accounts.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/accounts.scss
@@ -12,9 +12,14 @@
 	.account {
 		&__display-name {
 			color: $secondary-text-color;
-	
 			strong { color: $primary-text-color }
 		}
+	}
+
+	&-role {
+		color: $primary-lighter2-text-color;
+		background-color: rgba($base-separation-color, 0.1);
+		border-color: rgba($base-separation-color, 0.5);
 	}
 }
 
@@ -29,11 +34,70 @@
 	.account__header {
 		background-color: $account-foreground-color;
 
-		> div { background-color: inherit }
+		> div { background-color: inherit } // -> v2.7.4
 
 		.account__header {
 			&__username { color: $secondary-lighter1-text-color }
 			&__fields { @extend .account__header__fields; }
+
+			&__image { // v2.8.0 ->
+				&::after {
+					content: "";
+
+					position: absolute;
+					top: auto;
+					left: 0;
+					bottom: 0;
+	
+					width: 100%;
+					height: 30%;
+					background: $account-header-image-shadow-color;
+					box-shadow: none;
+				}
+
+				> img:not([src]),
+				> img[src$="/headers/original/missing.png"] {
+					content: url("https://raw.githubusercontent.com/GenbuProject/GPlusTheme-for-Mastodon/asset/account-default_header.jpg");
+				}
+			}
+
+			&__bar { // v2.8.0 ->
+				background-color: $base-lighter1-color;
+
+				.account__header {
+					&__tabs {
+						.avatar {
+							.account__avatar {
+								border-color: $base-lighter1-color;
+								border-radius: 50%;
+							}
+						}
+
+						&__buttons {
+							.icon-button { border: 0 }
+						}
+
+						&__name {
+							h1 { color: $primary-text-color }
+							small { color: $secondary-text-color }
+						}
+					}
+
+					&__bio {
+						.account__header {
+							&__content { color: $primary-text-color }
+							&__fields { border-color: $base-separation-color }
+						}
+					}
+
+					&__extra {
+						&__links {
+							&, a { color: $primary-lighter1-text-color }
+							strong { color: $primary-lighter2-text-color }
+						}
+					}
+				}
+			}
 		}
 
 		.account--action-button {
@@ -53,7 +117,7 @@
 		&__disclaimer,
 		&__action-bar,
 		&__section-headline {
-			background: $column-header-color;
+			background: $base-lighter1-color;
 			border-color: $base-separation-color;
 		}
 
@@ -71,12 +135,30 @@
 				color: $primary-text-color;
 	
 				&.active {
-					color: $primary-lighter1-text-color;
+					color: $active-color;
 	
 					&::before { border-color: transparent transparent $base-separation-color }
 					&::after { border-color: transparent transparent $status-color }
 				}
 			}
+		}
+	}
+}
+
+.account-authorize__wrapper {
+	@include status-shadow;
+	background: $base-lighter1-color;
+
+	&:focus { @include status-focus-shadow; }
+
+	.account {
+		&__header__content {
+			color: $primary-lighter2-text-color;
+		}
+	
+		&--panel {
+			background: $account-color;
+			border-color: $base-separation-color;
 		}
 	}
 }
@@ -88,7 +170,7 @@
 		dt,
 		dd {
 			color: $primary-text-color;
-			background: $column-header-color;
+			background: $base-lighter1-color;
 		}
 
 		dd {

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/columns.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/columns.scss
@@ -98,7 +98,6 @@
 .column {
 	.column-header {
 		@include column-shadow;
-		@include material-card-radius;
 		background: $column-header-color;
 
 		&.active {
@@ -158,11 +157,8 @@
 	}
 
 	.column {
-		&-subheading {
-			color: $secondary-text-color;
-			background: $base-color;
-			border-top: $base-separation-color solid 1px;
-		}
+		&-subheading,
+		&-link__badge { background: darken($base-color, 10%) }
 	
 		&-link {
 			color: $primary-text-color;
@@ -184,6 +180,8 @@
 			article {
 				margin: 1em 0;
 				&:first-of-type { margin: 0 }
+
+				&:focus { outline: none }
 			}
 		}
 

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/components-button.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/components-button.scss
@@ -11,11 +11,11 @@
 	width: 3.6rem;
 	height: 3.6rem;
 
-	&::active {
+	&:active {
 		background-color: $active-color;
 	}
 
-	&::hover {
+	&:hover {
 		background-color: $floating-acton-button-hover-color;
 	}
 }

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/components-status-card.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/components-status-card.scss
@@ -1,0 +1,12 @@
+@charset "UTF-8";
+
+@import 'variables';
+
+
+
+.status-card {
+	color: $primary-lighter1-text-color;
+	&__title, &__description { color: $primary-lighter2-text-color }
+
+	&__image { background: transparent }
+}

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/components.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/components.scss
@@ -3,3 +3,4 @@
 @import 'components-button';
 @import 'components-card';
 @import 'components-dropdown';
+@import 'components-status-card';

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/emoji-picker.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/emoji-picker.scss
@@ -1,0 +1,68 @@
+@charset "UTF-8";
+
+@import 'variables';
+@import 'mixins';
+
+
+
+.emoji-mart {
+    &-bar {
+        border: 0 solid $base-separation-color;
+
+        &:first-child {
+            border-top-left-radius: 2px;
+            border-top-right-radius: 2px;
+            background-color: $base-color;
+        }
+    }
+
+    &-anchors {
+        color: $icon-color;
+    }
+    &-anchor {
+        &-selected {
+            color: $icon-active-color;
+
+            &:hover {
+                color: $icon-active-color;
+            }
+        }
+
+        &-bar {
+            background-color: $icon-active-color;
+        }
+    }
+
+    &-search {
+        background-color: $base-lighter1-color;
+    }
+    &-search input {
+        color: $primary-text-color;
+        background-color: $form-color;
+        border: 0px solid #ffffff00;
+    }
+
+    &-category-label span {
+        color: $primary-text-color;
+        background-color: $base-lighter1-color;
+    }
+
+    &-scroll {
+        background-color: $base-lighter1-color;
+    }
+}
+
+.emoji-picker-dropdown {
+    &__modifiers {
+        &__menu {
+            @include status-shadow;
+            @include material-card-radius;
+            background-color: $base-lighter1-color;
+        }
+    }
+
+    &__menu {
+        @include column-shadow;
+        background-color: $base-lighter1-color;
+    }
+}

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/explore.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/explore.scss
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 
 @import 'variables';
+@import 'mixins';
 
 
 
@@ -11,6 +12,9 @@
 		h1 { color: $primary-text-color }
 		p { color: $primary-lighter2-text-color }
 	}
+
+	.directory,
+	.notice-widget { @include column-shadow; }
 
 	.directory {
 		background: $explore-directory-color;
@@ -23,9 +27,14 @@
 		}
 
 		&__tag {
-			a { background: $explore-directory-color }
-			h4 { color: $primary-text-color }
+			& > a {
+				@include status-shadow;
+				background: $explore-directory-color;
+			}
+
+			h4 { color: $primary-lighter2-text-color }
 			.fa, small { color: $primary-lighter1-text-color }
+			.trends__item__current { color: $primary-text-color }
 		}
 	}
 

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/keyboard_shortcuts.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/keyboard_shortcuts.scss
@@ -1,0 +1,21 @@
+@charset "UTF-8";
+
+@import 'variables';
+@import 'mixins';
+
+
+
+.keyboard-shortcuts {
+	kbd {
+		@include status-shadow;
+
+		color: $primary-text-color;
+		background-color: $base-lighter1-color;
+		border-color: $base-darker1-color;
+
+		margin: 0 0.25em;
+
+		&:first-child { margin-left: 0 }
+		&:last-child { margin-right: 0 }
+	}
+}

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/lists.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/lists.scss
@@ -22,13 +22,34 @@
 }
 
 .modal-root {
+	.column-inline-form {
+		background: $column-header-color;
+		
+		.setting-text {
+			color: $primary-text-color;
+			&:active, &:focus { color: $primary-lighter2-text-color }
+		}
+	}
+
 	.list-editor {
 		background: $base-color;
-		
 		h4 { background: $column-header-color }
 
 		.drawer__pager {
 			.drawer__inner { background: $column-header-color }
+		}
+	}
+
+	.list-adder {
+		background: $base-color;
+
+		.column-inline-form { border-bottom: 1px solid $base-separation-color }
+
+		&__account,
+		&__lists { background: $column-header-color }
+
+		&__lists {
+			.list { border-color: $base-separation-color }
 		}
 	}
 }

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/profile.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/profile.scss
@@ -23,7 +23,7 @@
 		svg path {
 			/* Only for Itabashi-don */
 			&:not(#Mastodon):not(#Itabashi) { fill: $secondary-text-color !important }
-			&:last-child { fill: $base-lighter1-color !important }
+			&#Mastodon { fill: $base-lighter1-color !important }
 		}
 	}
 
@@ -36,6 +36,8 @@
 			@media screen and (min-width: 600px) { height: 500px }
 
 			&::after {
+				content: "";
+				
 				position: absolute;
 				top: auto;
 				left: 0;
@@ -112,7 +114,7 @@
 						svg path {
 							/* Only for Itabashi-don */
 							&:not(#Mastodon):not(#Itabashi) { fill: $base-lighter1-color !important }
-							&:last-child { fill: $secondary-text-color !important }
+							&#Mastodon { fill: $secondary-text-color !important }
 						}
 					}
 				}
@@ -147,8 +149,11 @@
 		}
 	}
 
+	.public-account-bio,
+	.endorsements-widget,
+	.hero-widget { @include status-shadow; }
+
 	.public-account-bio {
-		@include column-shadow;
 		background: $base-lighter1-color;
 		
 		.account__header__content { color: $primary-text-color }
@@ -156,8 +161,6 @@
 	}
 
 	.endorsements-widget {
-		@include column-shadow;
-
 		padding-bottom: 0;
 		border-radius: 4px;
 
@@ -168,8 +171,6 @@
 	}
 
 	.hero-widget {
-		@include column-shadow;
-
 		&__img { background: $base-color }
 		&__text {
 			background: $base-lighter1-color;
@@ -224,7 +225,7 @@
 			svg path {
 				/* Only for Itabashi-don */
 				&:not(#Mastodon):not(#Itabashi) { fill: $secondary-text-color !important }
-				&:last-child { fill: $base-lighter1-color !important }
+				&#Mastodon { fill: $base-lighter1-color !important }
 			}
 		}
 	}

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-account.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-account.scss
@@ -10,7 +10,15 @@
 			> a {
 				position: relative;
 
-				.card__img { border-bottom: 1px solid $base-separation-color }
+				.card__img {
+					border-bottom: 1px solid $base-separation-color;
+
+					> img:not([src]),
+					> img[src="/headers/original/missing.png"] {
+						content: url("https://raw.githubusercontent.com/GenbuProject/GPlusTheme-for-Mastodon/asset/account-default_header.jpg");
+					}
+				}
+				
 				.card__bar {
 					position: static;
 					padding-top: 30%;
@@ -29,6 +37,8 @@
 						img {
 							width: 128px;
 							height: 128px;
+
+							border-radius: 50%;
 						}
 					}
 			

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-dashboard.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-dashboard.scss
@@ -18,7 +18,9 @@
 			}
 		}
 
+		&__text,
 		&__num { color: $primary-text-color }
+		
 		&__label { color: $primary-lighter1-text-color }
 	}
 

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-directory_tag.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-directory_tag.scss
@@ -1,0 +1,21 @@
+@charset "UTF-8";
+
+@import 'variables';
+
+
+
+.admin-wrapper {
+	.content {
+		.directory__tag {
+			& > a,
+			& > div { background: $setting-base-color }
+
+			h4 {
+				& { color: $primary-lighter2-text-color }
+				.fa, small { color: $primary-lighter1-text-color }
+			}
+
+			.trends__item__current { color: $primary-text-color }
+		}
+	}
+}

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-log.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-log.scss
@@ -1,0 +1,30 @@
+@charset "UTF-8";
+
+@import 'variables';
+
+
+
+.log-entry {
+	.log-entry {
+		&__header {
+			color: $primary-lighter2-text-color;
+			background: $log-entry-color;
+
+			.username,
+			.target,
+			a { color: $secondary-text-color }
+		}
+
+		&__timestamp { color: $primary-lighter1-text-color }
+		&__icon { color: $icon-color }
+
+		&__extras {
+			color: $primary-text-color;
+			background: $log-entry-extra-color;
+
+			.diff-neutral { color: $log-entry-extra--neutral-color }
+			.diff-old { color: $log-entry-extra--old-color }
+			.diff-new { color: $log-entry-extra--new-color }
+		}
+	}
+}

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-report.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/settings-report.scss
@@ -45,14 +45,26 @@
 	}
 
 	&__row {
-		background: $base-lighter1-color;
-		border-color: $base-separation-color;
+		&, &:nth-child(2n) { background: $base-lighter1-color }
+		&:hover, &:nth-child(2n):hover { background: $column-header-hover-color }
 
-		&:hover { background: $column-header-hover-color }
+		border-color: $base-separation-color;
 
 		&__content {
 			.status__content { color: $primary-text-color }
 			.detailed-status__meta { color: $primary-lighter1-text-color }
+
+
+			.accounts-table { // v2.8.0 ->
+				.accounts-table {
+					&__count {
+						& {color: $primary-text-color }
+						small { color: $primary-lighter1-text-color }
+					}
+				}
+
+				td .account { background: inherit }
+			}
 		}
 	}
 }

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/settings.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/settings.scss
@@ -4,7 +4,9 @@
 @import 'mixins';
 @import 'settings-account';
 @import 'settings-report';
+@import 'settings-log';
 @import 'settings-dashboard';
+@import 'settings-directory_tag';
 
 
 
@@ -82,7 +84,10 @@ body.admin {
 			.radio label { color: $primary-text-color }
 		}
 
-		&-copy { background: $base-color }
+		&-copy {
+			background: $base-color;
+			border-color: $base-separation-color;
+		}
 	}
 
 	.check_boxes {
@@ -123,7 +128,20 @@ body.admin {
 		}
 	}
 
-	.hint, p.hint { color: $primary-lighter1-text-color !important }
+	.hint, p.hint {
+		color: $primary-lighter1-text-color !important;
+
+		code {
+			color: $light-text-color;
+			background: $setting-emphasis-color;
+		}
+	}
+
+	.recommended {
+		color: $verified-color;
+		background-color: transparentize($verified-color, 0.75);
+		border-color: $verified-color;
+	}
 
 	.label_input {
 		&__append { color: $primary-lighter1-text-color }
@@ -182,11 +200,19 @@ body.admin {
 	}
 }
 
-label {
-	&[for=user_setting_default_privacy_public],
-	&[for=user_setting_default_privacy_unlisted] {
-		color: $active-text-color !important;
+.new_form_two_factor_confirmation {
+	.qr-wrapper {
+		.qr-code { box-shadow: none }
+		.qr-alternative { color: $secondary-lighter1-text-color }
 	}
+}
+
+label,
+select#user_setting_default_privacy {
+	&[for=user_setting_default_privacy_public],
+	&[for=user_setting_default_privacy_unlisted],
+	option[value="public"],
+	option[value="unlisted"] { color: $active-text-color !important }
 }
 
 .column-header__collapsible__extra {

--- a/app/javascript/styles/gplus-theme-for-mastodon-dev/statuses.scss
+++ b/app/javascript/styles/gplus-theme-for-mastodon-dev/statuses.scss
@@ -56,19 +56,17 @@
 }
 
 .detailed-status {
-	.detailed-status {
-		&__display-name {
-			color: $secondary-text-color;
-	
-			strong { color: $primary-text-color }
-		}
-	
-		&__meta {
-			.detailed-status__datetime { color: $primary-lighter1-text-color }
-	
-			.detailed-status__link {
-				.fa.fa-star { vertical-align: middle }
-			}
+	&__display-name {
+		color: $secondary-text-color;
+
+		strong { color: $primary-text-color }
+	}
+
+	&__meta {
+		.detailed-status__datetime { color: $primary-lighter1-text-color }
+
+		.detailed-status__link {
+			.fa.fa-star { vertical-align: middle }
 		}
 	}
 	


### PR DESCRIPTION
絵文字ピッカーのテーマ適用
ダークテーマをマテリアルデザインガイドラインに準拠
ダークテーマでの青文字を見やすく
不具合の修正