### PR TITLE
Mastodon Autoテーマ向け修正

### DIFF
--- a/app/javascript/styles/mastodon/accessibility.scss
+++ b/app/javascript/styles/mastodon/accessibility.scss
@@ -7,7 +7,7 @@ $emojis-requiring-inversion: 'back' 'copyright' 'curly_loop' 'currency_exchange'
 .emojione {
   @each $emoji in $emojis-requiring-inversion {
     &[title=':#{$emoji}:'] {
-      @extend %emoji-color-inversion;
+      filter: invert(1);
     }
   }
 }


### PR DESCRIPTION
Mastodon Autoテーマが正常に動作するように変更を加えました。これまでと違い公式部分に手を加えたため、今後の変更によってはコンフリクトが発生する場合があります。

Q. %emoji-color-inversionセレクタを残したのはなぜ？
A. 今後セレクタ内に要素が追加されたとき(私にはそれが起こるようには見えない…)にコンフリクトを避け、かつ変更点が分かりやすいようにするための妥協案です。